### PR TITLE
Added color text when a command name is listed more than once

### DIFF
--- a/lib/nodes/help.js
+++ b/lib/nodes/help.js
@@ -20,19 +20,38 @@ module.exports = (props, children) => {
     str += NEWLINE;
     str += 'Commands:' + NEWLINE;
 
-    // get the largest name size
+    // get the largest command name size
+    // also count the number of instances of a command
     let maxLen = 0;
+    let cmdUseCount = {};
     for (let i = 0; i < cmds.length; i++) {
-        if (cmds[i].props.name.length >= maxLen) {
+        const cmdName = cmds[i].props.name;
+
+        if (cmdName.length >= maxLen) {
             maxLen = cmds[i].props.name.length;
         }
+
+        cmdUseCount[cmdName] ? cmdUseCount[cmdName] += 1 : cmdUseCount[cmdName] = 1;
     }
 
     cmds.forEach(cmd => {
+        const hasMulti = cmdUseCount[cmd.props.name] > 1; 
+
+        // If cmd has multiple instances, start color text
+        if (hasMulti) { 
+            str += "\x1b[1m"; 
+        }
+
         str += TAB + cmd.props.name;
         str += ' '.repeat(maxLen - cmd.props.name.length);
         str += TAB + TAB;
         str += cmd.props.description;
+        
+        // If cmd has multiple instances, end color text
+        if (hasMulti) {
+            str += "\x1b[0m";
+        }
+
         str += NEWLINE;
     });
 


### PR DESCRIPTION
#4 

This adds yellow text to commands listed in the help section if there is a command name which is listed more than once.

Screenshot:
![capture](https://cloud.githubusercontent.com/assets/1796078/24426741/7a97b786-13bd-11e7-84fc-9711e01541af.PNG)
