### PR TITLE
Fixed render issue when <div> or <ul> is used after an inline element

### DIFF
--- a/__tests__/nodes/div.js
+++ b/__tests__/nodes/div.js
@@ -5,6 +5,6 @@ describe('<div />', () => {
     it('should render a <div /> element', () => {
         const node = <div>foobar</div>;
         const output = renderTree(node);
-        expect(output).toEqual('foobar\n');
+        expect(output).toEqual('\nfoobar');
     });
 });

--- a/__tests__/nodes/ul.js
+++ b/__tests__/nodes/ul.js
@@ -5,7 +5,7 @@ describe('<ul/>', () => {
     it('should render a <ul/> element', () => {
         const node = <ul><li>foobar</li></ul>;
         const output = renderTree(node);
-        expect(output).toEqual('\t\u2022foobar\n\n');
+        expect(output).toEqual('\n\t\u2022foobar\n');
     });
 });
 

--- a/__tests__/render.js
+++ b/__tests__/render.js
@@ -140,7 +140,7 @@ describe('render', () => {
         }
 
         expect(renderTree(<ExampleList />))
-            .toEqual('\t\u2022\u001b[1mfoo\u001b[0m\n\t\u2022\u001b[1mbar\u001b[0m\n\n');
+            .toEqual('\n\t\u2022\u001b[1mfoo\u001b[0m\n\t\u2022\u001b[1mbar\u001b[0m\n');
 
     });
 });

--- a/lib/nodes/div.js
+++ b/lib/nodes/div.js
@@ -1,5 +1,5 @@
-const PREFIX = '';
-const SUFFIX = '\n';
+const PREFIX = '\n';
+const SUFFIX = '';
 
 module.exports = (props, children) => {
     if (typeof children === 'string') {

--- a/lib/nodes/ul.js
+++ b/lib/nodes/ul.js
@@ -1,5 +1,5 @@
-const PREFIX = '';
-const SUFFIX = '\n';
+const PREFIX = '\n';
+const SUFFIX = '';
 
 module.exports = (props, children) => {
     if (typeof children === 'string') {


### PR DESCRIPTION
When block elements `<div>` and `<ul>` are used after an inline element such as `<span>`, the `<div>` and `<ul>` are still inline as the newline is at the suffix.  This PR fixes it by moving the newline to the prefix.

Example, given two structures:
```
function blockInline() {
    return (
        <div>
            <span>This is a span that is inline.</span>
            <div>This is a div that should be on a newline.</div>
        </div>
    );
}
```

```
function list() {
    return (
        <div>
            <span>Span title</span>
            <ul>
                <li>Item 1</li>
                <li>Item 2</li>
            </ul>
        </div>
    );
}
```

Before:
![screenshot_1](https://cloud.githubusercontent.com/assets/1796078/24693677/92c33886-1993-11e7-8e5f-dcb5ef3ff725.png)

After:
![screenshot_2](https://cloud.githubusercontent.com/assets/1796078/24693626/53674380-1993-11e7-96e1-b764fbdd904c.png)

 