### PR TITLE
For <div>, add newlines to text nodes rather than the element

### DIFF
--- a/__tests__/nodes/div.js
+++ b/__tests__/nodes/div.js
@@ -7,4 +7,22 @@ describe('<div />', () => {
         const output = renderTree(node);
         expect(output).toEqual('\nfoobar');
     });
+
+    it('should be empty if <div /> is empty', () => {
+        const node = <div></div>;
+        const output = renderTree(node);
+        expect(output).toEqual('');
+    });
+
+    it('should add prefix newlines on text nodes', () => {
+        const node = (
+            <div>
+                <div></div>
+                Text 1
+                <div>Text 2</div>
+            </div>
+        );
+        const output = renderTree(node);
+        expect(output).toEqual('\nText 1\nText 2');
+    });
 });

--- a/lib/nodes/div.js
+++ b/lib/nodes/div.js
@@ -2,9 +2,15 @@ const PREFIX = '\n';
 const SUFFIX = '';
 
 module.exports = (props, children) => {
+    // If a node has children: For each string node, add a prefix and suffix.
+    if (children.length > 0) {
+        return children.map(node => (typeof node === 'string' ? (PREFIX + node + SUFFIX) : node));
+    }
+
     if (typeof children === 'string') {
         return PREFIX + children + SUFFIX;
     }
 
-    return [PREFIX, children, SUFFIX];
+    // When there is no child, simply return.
+    return [children];
 };


### PR DESCRIPTION
Each time `<div>` is used within the command tree, a newline is prefixed for the element itself.  Unnecessary newlines make the output particularly ugly; `<div>`s should function more like wrappers or containers.

This PR fixes it by moving the prefixed newlines to the text nodes instead of the element itself.

Example:
```
function divitis() {
    return (
        <div>
            <div>Div 1</div>
            { /* Div 2 is empty */ }
            <div></div>
            <div>
                <div>Div 3-1</div>
                { /* Div 3-2 is empty */ }
                <div></div>
                <div>Div 3-3</div>
            </div>
            { /* Div 4 is empty */ }
            <div>
                <div></div>
            </div>
            <div>
                Div 5#top
                <div>Div 5-1</div>
                <div>Div 5-2</div>
                Div 5#bottom
            </div>
        </div>
    );
}
```

Before:
![screenshot_4](https://cloud.githubusercontent.com/assets/1796078/24704043/cddd14b0-19ba-11e7-8e4a-45e621c97f62.png)

After:
![screenshot_3](https://cloud.githubusercontent.com/assets/1796078/24704049/d4081542-19ba-11e7-9717-1d237c4806b2.png)

